### PR TITLE
request has `scope` field to be returned in response

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -14,15 +14,19 @@ type Claims struct {
 	jwt.MapClaims
 }
 
-func New(subject, issuer, audience string, customClaims map[string]interface{}) Claims {
-	claims := Claims{}
-	claims.StandardClaims =
+func New(subject string, issuer string, audience string, scope string, customClaims map[string]interface{}) Claims {
+	claims := Claims{
 		jwt.StandardClaims{
 			Subject:   subject,
 			Issuer:    issuer,
 			Audience:  audience,
 			ExpiresAt: time.Now().AddDate(1, 0, 0).Unix(),
-		}
+		},
+		jwt.MapClaims{
+			"scope": scope,
+		},
+	}
+
 	for k, v := range customClaims {
 		claims.Add(k, v)
 	}

--- a/transport/http/handlers.go
+++ b/transport/http/handlers.go
@@ -29,7 +29,12 @@ func CreateTokenHandler(key interface{}, issuer string) func(w http.ResponseWrit
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 
-		claims := jwt.New(tokenRequest.Subject, issuer, tokenRequest.Audience, tokenRequest.CustomClaims)
+		claims := jwt.New(
+			tokenRequest.Subject,
+			issuer,
+			tokenRequest.Audience,
+			tokenRequest.Scope,
+			tokenRequest.CustomClaims)
 
 		token := jwtgo.NewWithClaims(jwtgo.SigningMethodRS256, claims)
 		s, e := token.SignedString(key)

--- a/transport/http/token_request.go
+++ b/transport/http/token_request.go
@@ -9,6 +9,7 @@ type TokenRequest struct {
 	CustomClaims map[string]interface{} `json:"custom_claims"`
 	Subject      string                 `json:"subject"`
 	Audience     string                 `json:"audience"`
+	Scope        string                 `json:"scope"`
 }
 
 func GetTokenRequest(r *http.Request) (TokenRequest, error) {


### PR DESCRIPTION
In order to support auth0 scopes, a new `scope` property is available in the request payload